### PR TITLE
add color_identities

### DIFF
--- a/lib/mtg_sdk/card.rb
+++ b/lib/mtg_sdk/card.rb
@@ -9,15 +9,15 @@ module MTG
                   :rarity, :text, :flavor, :artist, :number, :power, :toughness, :loyalty, :multiverse_id, :variations,
                   :watermark, :border, :timeshifted, :hand, :life, :reserved, :release_date, :starter,
                   :rulings, :foreign_names, :printings, :original_text, :original_type, :legalities,
-                  :source, :image_url, :set, :id, :set_name
-    
+                  :source, :image_url, :set, :id, :set_name, :color_identities
+
     # Get the resource string
     #
     # @return [String] The API resource string
     def self.Resource
       "cards"
     end
-    
+
     # Find a single card by the card multiverse id
     #
     # @param id [Integer] the multiverse id
@@ -32,7 +32,7 @@ module MTG
     def self.all
       QueryBuilder.new(Card).all
     end
-    
+
     # Adds a parameter to the hash of query parameters
     #
     # @param args [Hash] the query parameter

--- a/lib/mtg_sdk/card.rb
+++ b/lib/mtg_sdk/card.rb
@@ -9,7 +9,7 @@ module MTG
                   :rarity, :text, :flavor, :artist, :number, :power, :toughness, :loyalty, :multiverse_id, :variations,
                   :watermark, :border, :timeshifted, :hand, :life, :reserved, :release_date, :starter,
                   :rulings, :foreign_names, :printings, :original_text, :original_type, :legalities,
-                  :source, :image_url, :set, :id, :set_name, :color_identities
+                  :source, :image_url, :set, :id, :set_name, :color_identity
 
     # Get the resource string
     #

--- a/lib/mtg_sdk/representers/card_representer.rb
+++ b/lib/mtg_sdk/representers/card_representer.rb
@@ -11,7 +11,7 @@ module MTG
   module CardRepresenter
     include Roar::JSON
     include Roar::Coercion
-    
+
     property :name
     property :layout
     property :mana_cost, as: :manaCost
@@ -41,12 +41,13 @@ module MTG
     property :set_name, as: :setName
     property :id
     property :image_url, as: :imageUrl
-    
+
     collection :names
     collection :supertypes
     collection :subtypes
     collection :types
     collection :colors
+    collection :color_identities, as: :colorIdentity
     collection :variations
     collection :printings
     collection :legalities, extend: LegalityRepresenter, class: Legality

--- a/lib/mtg_sdk/representers/card_representer.rb
+++ b/lib/mtg_sdk/representers/card_representer.rb
@@ -47,7 +47,7 @@ module MTG
     collection :subtypes
     collection :types
     collection :colors
-    collection :color_identities, as: :colorIdentity
+    collection :color_identity, as: :colorIdentity
     collection :variations
     collection :printings
     collection :legalities, extend: LegalityRepresenter, class: Legality

--- a/test/card_test.rb
+++ b/test/card_test.rb
@@ -11,6 +11,7 @@ class CardTest < Minitest::Test
       assert_equal 6, card.cmc
       assert_equal 'Sorcery — Arcane', card.type
       assert card.colors.any?{|color| color == 'Black'}
+      assert card.color_identities.any?{|color_id| color == 'B'}
       assert card.types.any?{|type| type == 'Sorcery'}
       assert card.subtypes.any?{|subtype| subtype == 'Arcane'}
       assert_equal 'Rare', card.rarity
@@ -32,7 +33,7 @@ class CardTest < Minitest::Test
       assert_equal '1c4aab072d52d283e902f2302afa255b39e0794b', card.id
     end
   end
-  
+
   def test_find_with_invalid_id_throws_exception
     VCR.use_cassette('invalid_id') do
       assert_raises ArgumentError do
@@ -40,7 +41,7 @@ class CardTest < Minitest::Test
       end
     end
   end
-  
+
   def test_where_with_page_size_and_page_returns_cards
     VCR.use_cassette('query_cards_pageSize') do
       cards = MTG::Card.where(pageSize: 10).where(page: 1).all
@@ -64,17 +65,17 @@ class CardTest < Minitest::Test
       assert first_card.subtypes.include? 'Warrior'
     end
   end
-  
+
   def test_all_returns_all_cards
     VCR.use_cassette('all_cards') do
       stub_request(:any, "https://api.magicthegathering.io/v1/cards").
         to_return(:body => File.new('test/responses/sample_cards.json'), :status => 200, :headers => {"Content-Type"=> "application/json"})
-      
+
       stub_request(:any, "https://api.magicthegathering.io/v1/cards?page=2").
         to_return(:body => File.new('test/responses/no_cards.json'), :status => 200, :headers => {"Content-Type"=> "application/json"})
-        
+
       cards = MTG::Card.all
-      
+
       assert_equal 2, cards.length
     end
   end

--- a/test/card_test.rb
+++ b/test/card_test.rb
@@ -11,7 +11,7 @@ class CardTest < Minitest::Test
       assert_equal 6, card.cmc
       assert_equal 'Sorcery — Arcane', card.type
       assert card.colors.any?{|color| color == 'Black'}
-      assert card.color_identities.any?{|color_id| color == 'B'}
+      assert card.color_identity.any?{|color_id| color_id == 'B'}
       assert card.types.any?{|type| type == 'Sorcery'}
       assert card.subtypes.any?{|subtype| subtype == 'Arcane'}
       assert_equal 'Rare', card.rarity


### PR DESCRIPTION
I added the color_identities collection as an attribute of generated card objects. This is essential for checking Commander deck legality and can be useful for improved card search. 
I also added a line to the card test file to address the new feature.