### PR TITLE
Service Unavailable

### DIFF
--- a/lib/mtg_sdk/query_builder.rb
+++ b/lib/mtg_sdk/query_builder.rb
@@ -2,7 +2,7 @@ module MTG
   class QueryBuilder
     include RestClient
     attr_accessor :type, :query
-    
+
     def initialize(type)
       @type = type
       @query = {}
@@ -16,7 +16,7 @@ module MTG
       @query.merge!(args)
       self
     end
-    
+
     # Find a single resource by the resource id
     #
     # @param id [String] the resource id
@@ -24,13 +24,13 @@ module MTG
     def find(id)
       response = RestClient.get("#{@type.Resource}/#{id}")
       singular_resource = @type.Resource[0...-1]
-      if response.body[singular_resource].nil?
-        raise ArgumentError, 'Resource not found'
-      end
-      
+
+      raise ArgumentError, 'Resource not found' if response.body[singular_resource].nil?
+      raise ArgumentError, 'Unavailable Service' if unavailable_service?(response)
+
       type.new.from_json(response.body[singular_resource].to_json)
     end
-    
+
     # Get all resources from a query by paging through data
     #
     # @return [Array<Object>] Array of resources
@@ -43,13 +43,16 @@ module MTG
         page = @query[:page]
         fetch_all = false
       end
-      
+
       while true
         response = RestClient.get(@type.Resource, @query)
-        data = response.body[@type.Resource]      
+        data = response.body[@type.Resource]
+
+        raise ArgumentError, 'Unavailable Service' if unavailable_service?(response)
+
         if !data.empty?
           data.each {|item| list << @type.new.from_json(item.to_json)}
-          
+
           if !fetch_all
             break
           else
@@ -61,6 +64,12 @@ module MTG
       end
 
       return list
+    end
+
+    private
+
+    def unavailable_service?(response)
+      (500..599).include?(response.status)
     end
   end
 end

--- a/test/fixtures/service_unavailable.yml
+++ b/test/fixtures/service_unavailable.yml
@@ -1,0 +1,103 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.magicthegathering.io/v1/sets/ktk
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 503
+      message: Service Unavailable
+    headers:
+      Date:
+      - Tue, 12 Nov 2019 21:57:20 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d7ab5b633f320ea731b6b83d869e77f041573595810; expires=Wed, 11-Nov-20
+        21:56:50 GMT; path=/; domain=.magicthegathering.io; HttpOnly; Secure
+      Cache-Control:
+      - no-cache, no-store
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 534bc215effcd7e9-EZE
+    body:
+      encoding: UTF-8
+      string: "<!DOCTYPE html>\n\t<html>\n\t  <head>\n\t\t<meta name=\"viewport\"
+        content=\"width=device-width, initial-scale=1\">\n\t\t<meta charset=\"utf-8\">\n\t\t<title>Application
+        Error</title>\n\t\t<style media=\"screen\">\n\t\t  html,body,iframe {\n\t\t\tmargin:
+        0;\n\t\t\tpadding: 0;\n\t\t  }\n\t\t  html,body {\n\t\t\theight: 100%;\n\t\t\toverflow:
+        hidden;\n\t\t  }\n\t\t  iframe {\n\t\t\twidth: 100%;\n\t\t\theight: 100%;\n\t\t\tborder:
+        0;\n\t\t  }\n\t\t</style>\n\t  </head>\n\t  <body>\n\t\t<iframe src=\"//www.herokucdn.com/error-pages/application-error.html\"></iframe>\n\t
+        \ </body>\n\t</html>"
+    http_version: 
+  recorded_at: Tue, 12 Nov 2019 21:57:20 GMT
+- request:
+    method: get
+    uri: https://api.magicthegathering.io/v1/sets
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 503
+      message: Service Unavailable
+    headers:
+      Date:
+      - Tue, 12 Nov 2019 21:57:20 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d7ab5b633f320ea731b6b83d869e77f041573595810; expires=Wed, 11-Nov-20
+        21:56:50 GMT; path=/; domain=.magicthegathering.io; HttpOnly; Secure
+      Cache-Control:
+      - no-cache, no-store
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 534bc215effcd7e9-EZE
+    body:
+      encoding: UTF-8
+      string: "<!DOCTYPE html>\n\t<html>\n\t  <head>\n\t\t<meta name=\"viewport\"
+        content=\"width=device-width, initial-scale=1\">\n\t\t<meta charset=\"utf-8\">\n\t\t<title>Application
+        Error</title>\n\t\t<style media=\"screen\">\n\t\t  html,body,iframe {\n\t\t\tmargin:
+        0;\n\t\t\tpadding: 0;\n\t\t  }\n\t\t  html,body {\n\t\t\theight: 100%;\n\t\t\toverflow:
+        hidden;\n\t\t  }\n\t\t  iframe {\n\t\t\twidth: 100%;\n\t\t\theight: 100%;\n\t\t\tborder:
+        0;\n\t\t  }\n\t\t</style>\n\t  </head>\n\t  <body>\n\t\t<iframe src=\"//www.herokucdn.com/error-pages/application-error.html\"></iframe>\n\t
+        \ </body>\n\t</html>"
+    http_version: 
+  recorded_at: Tue, 12 Nov 2019 21:57:20 GMT
+recorded_with: VCR 3.0.3

--- a/test/set_test.rb
+++ b/test/set_test.rb
@@ -4,7 +4,7 @@ class SetTest < Minitest::Test
   def test_find_returns_one_set
     VCR.use_cassette('one_set') do
       set = MTG::Set.find('ktk')
-      
+
       assert_equal 'KTK', set.code
       assert_equal 'Khans of Tarkir', set.name
       assert_equal 'expansion', set.type
@@ -14,7 +14,7 @@ class SetTest < Minitest::Test
       assert_equal 'ktk', set.magic_cards_info_code
     end
   end
-  
+
   def test_find_with_invalid_code_throws_exception
     VCR.use_cassette('invalid_code') do
       assert_raises ArgumentError do
@@ -22,11 +22,11 @@ class SetTest < Minitest::Test
       end
     end
   end
-  
+
   def test_all_returns_all_sets
     VCR.use_cassette('all_sets') do
       sets = MTG::Set.all
-      
+
       assert sets.length > 100
     end
   end
@@ -40,13 +40,33 @@ class SetTest < Minitest::Test
       assert_equal 'Khans of Tarkir', set.name
     end
   end
-  
+
   def test_generate_booster_returns_cards
     VCR.use_cassette('booster') do
       cards = MTG::Set.generate_booster('ktk')
-      
+
       assert cards.length == 15
       assert_equal 'KTK', cards.first.set
+    end
+  end
+
+  def test_service_unavailable
+    VCR.use_cassette('service_unavailable') do
+      assert_raises ArgumentError, "Unavailable Service" do
+        MTG::Set.find('ktk')
+      end
+
+      assert_raises ArgumentError, "Unavailable Service" do
+        MTG::Set.all
+      end
+    end
+  end
+
+  def test_service_timeout
+    VCR.use_cassette('service_timeout') do
+      assert_raises ArgumentError, "Unavailable Service" do
+        MTG::Set.all
+      end
     end
   end
 end

--- a/test/set_test.rb
+++ b/test/set_test.rb
@@ -61,12 +61,4 @@ class SetTest < Minitest::Test
       end
     end
   end
-
-  def test_service_timeout
-    VCR.use_cassette('service_timeout') do
-      assert_raises ArgumentError, "Unavailable Service" do
-        MTG::Set.all
-      end
-    end
-  end
 end


### PR DESCRIPTION
Sometimes when API is down, QueryBuilder keeps raising `NoMethodError: nil.empty?` [here](https://github.com/MagicTheGathering/mtg-sdk-ruby/blob/master/lib/mtg_sdk/query_builder.rb#L50) when it should raise a specific kind of exception for the user.

Even though the `vcr fixtures` are created at CI time and ignored in this repo, the `service_unavailable.yml` should be checked in since this error depends on the server to be actually offline to happen, otherwise it'll fail all the ci builds.