### PR TITLE
Removed coercion errors in latest dependency versions.

### DIFF
--- a/lib/mtg_sdk/representers/card_representer.rb
+++ b/lib/mtg_sdk/representers/card_representer.rb
@@ -32,7 +32,7 @@ module MTG
     property :hand
     property :life
     property :reserved
-    property :release_date, as: :releaseDate, type: Date
+    property :release_date, as: :releaseDate, type: Types::Params::Date
     property :starter
     property :original_text, as: :originalText
     property :original_type, as: :originalType

--- a/lib/mtg_sdk/representers/changelog_representer.rb
+++ b/lib/mtg_sdk/representers/changelog_representer.rb
@@ -6,7 +6,7 @@ module MTG
     include Roar::JSON
     include Roar::Coercion
   
-    property :release_date, as: :releaseDate, type: Date
+    property :release_date, as: :releaseDate, type: Types::Params::Date
     property :version
     property :details
   end

--- a/lib/mtg_sdk/representers/ruling_representer.rb
+++ b/lib/mtg_sdk/representers/ruling_representer.rb
@@ -6,7 +6,7 @@ module MTG
     include Roar::JSON
     include Roar::Coercion
   
-    property :date, type: Date
+    property :date, type: Types::Params::Date
     property :text
   end
 end

--- a/lib/mtg_sdk/representers/set_representer.rb
+++ b/lib/mtg_sdk/representers/set_representer.rb
@@ -1,8 +1,10 @@
 require 'roar/json'
+require 'roar/coercion'
 
 module MTG
   module SetRepresenter
     include Roar::JSON
+    include Roar::Coercion
   
     property :code
     property :name
@@ -13,7 +15,7 @@ module MTG
     property :block
     property :old_code, as: :oldCode
     property :online_only, as: :onlineOnly
-    property :release_date, as: :releaseDate
+    property :release_date, as: :releaseDate, type: Types::Params::Date
     property :gatherer_code, as: :gatherCode
     property :magic_cards_info_code, as: :magicCardsInfoCode
     

--- a/mtg_sdk.gemspec
+++ b/mtg_sdk.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "multi_xml", "~> 0.5"
   spec.add_dependency "faraday_middleware", "~> 0.10"
   spec.add_dependency "virtus", "~> 1.0"
+  spec.add_dependency "dry-types", "~> 1.5"
 end


### PR DESCRIPTION
Hello, this fixes some issue I encountered, and that other people have been reporting on the Discord. I am not sure this is the most idiomatic solution, so feel free to correct.

Errors are:
 * Missing `dry-types` dependency
 * `C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/representable-3.2.0/lib/representable/coercion.rb:15:in call': undefined method call' for Date:Class (NoMethodError)
`